### PR TITLE
Support Korean

### DIFF
--- a/language.js
+++ b/language.js
@@ -1,6 +1,7 @@
-let lang = window.navigator.language || window.navigator.browserLanguage;
-if (lang.match(/ja/i)) {
-    let lang = {
+let langs = window.navigator.languages || window.navigator.browserLanguages;
+const translations = {
+    en: {}, // Default
+    ja: {
         "title": "週統計",
         "new-statuses": "トゥート数",
         "statuses": "トゥート",
@@ -8,9 +9,20 @@ if (lang.match(/ja/i)) {
         "login-users": "人",
         "registration": "新規登録数",
         "registration-users": "人"
-    }, key;
+    },
+}
 
-    for (key in lang) {
-        document.getElementById("text-"+key).innerText = lang[key];
+function getFirstMatchedLanguage() {
+    for (let lang of langs) {
+        if (lang in translations) {
+            return lang
+        }
+    }
+}
+
+let lang = translations[getFirstMatchedLanguage()];
+if (lang) {
+    for (let key in lang) {
+        document.getElementById(`text-${key}`).innerText = lang[key];
     }
 }

--- a/language.js
+++ b/language.js
@@ -10,6 +10,15 @@ const translations = {
         "registration": "新規登録数",
         "registration-users": "人"
     },
+    ko: {
+        "title": "주 통계",
+        "new-statuses": "툿 수",
+        "statuses": "툿",
+        "active-users": "로그인 수",
+        "login-users": "명",
+        "registration": "신규 등록 수",
+        "registration-users": "명"
+    },
 }
 
 function getFirstMatchedLanguage() {


### PR DESCRIPTION
* Get language from `navigator.languages` instead of `navigator.language`.
  It is list of preferred languages. If user set it like `['eo', 'es', 'ja', 'en']`, then first of supported language _ja_ is selected.
* Add Korean translation